### PR TITLE
Roadmap: add libsdformat12 for Fortress

### DIFF
--- a/developers/roadmap.md
+++ b/developers/roadmap.md
@@ -24,6 +24,8 @@ version supported by the given release of the library:
     * 10.0.0 (**released**): C++17, SDFormat 1.7.
 * `libsdformat11`: For use in Ignition Edifice.
     * 11.0.0 (**released**): C++17, SDFormat 1.8.
+* `libsdformat12`: For use in Ignition Fortress.
+    * 12.0.0 (**planned**): C++17, SDFormat 1.9.
 
 ## Downstream Library Support
 
@@ -44,6 +46,7 @@ specification (as well as the caveats):
     * Dome (**released**): libsdformat10, SDFormat 1.7, but only a subset:
         * Does not support directly nested models
     * Edifice (**released**): libsdformat11, SDFormat 1.8
+    * Fortress (**planned**): libsdformat12, SDFormat 1.9
 * [Drake](https://github.com/RobotLocomotion/drake/releases):
     * 0.10.0 - 0.13.0 (**released**): SDFormat 1.6, but deviates:
         * Does not support directly nested models


### PR DESCRIPTION
In [Roadmap](http://sdformat.org/tutorials?tut=roadmap&cat=developers&), added **planned** Fortress `libsdformat12` and `SDFormat 1.9` specification

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**