### PR TITLE
Improved quickstart tutorial

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -16,7 +16,7 @@
     </tutorial>
 
     <tutorial title="Quickstart" ref='quickstart'>
-      <markdown version="2.0">quickstart/tutorial_2-0.md</markdown>
+      <markdown version="X.0">quickstart/tutorial_2-0.md</markdown>
       <description>Quickstart guide to SDFormat parsing with libsdformat.</description>
       <tags>
         <tag>quickstart</tag>

--- a/quickstart/tutorial_2-0.md
+++ b/quickstart/tutorial_2-0.md
@@ -171,6 +171,7 @@ Copy the code into a file and name it `check_sdf.cc`. Along with it, add a `CMak
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 find_package(SDFormat REQUIRED)
+# find_package(sdformat<version of sdformat> REQUIRED) # sdformat7 or higher
 
 include_directories(${SDFormat_INCLUDE_DIRS})
 link_directories(${SDFormat_LIBRARY_DIRS})
@@ -178,6 +179,8 @@ link_directories(${SDFormat_LIBRARY_DIRS})
 add_executable(check_sdf check_sdf.cc)
 target_link_libraries(check_sdf ${SDFormat_LIBRARIES})
 ```
+
+**Note**: If you are using a higher version than 6 you should use to find the library `find_package(sdformat<version of sdformat> REQUIRED)`
 
 Now build it:
 


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

I noticed that `sdformat` was renamed from `SDFormat` to `sdformat<version>` in the `CMakeLists.txt`. Adding a note and changing the manifest to `X.0` to maintain only one tutorial 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
