### PR TITLE
Triage tickets to core dev board

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,20 @@
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+name: Ticket opened
+jobs:
+  assign:
+    name: Add ticket to inbox
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Add ticket to inbox
+        uses: technote-space/create-project-card-action@v1
+        with:
+          PROJECT: Core development
+          COLUMN: Inbox
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+          CHECK_ORG_PROJECT: true
+


### PR DESCRIPTION
Just noticed that PRs and issues from this repo weren't showing up on the board.