### PR TITLE
manifest.xml: fix proposal version and order

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -36,7 +36,7 @@
     </tutorial>
 
     <tutorial title="Proposal for a better pose" ref='better_pose_proposal' type='proposal'>
-      <markdown version="1.8">specify_pose/proposal.md</markdown>
+      <markdown version="1.9">specify_pose/proposal.md</markdown>
       <description>Specifying pose in SDFormat using different rotation representations.</description>
       <tags>
         <tag>pose</tag>

--- a/manifest.xml
+++ b/manifest.xml
@@ -270,9 +270,9 @@
       <tutorials>
         <tutorial>pose_frame_semantics_proposal</tutorial>
         <tutorial>custom_elements_attributes_proposal</tutorial>
+        <tutorial>param_passing_proposal</tutorial>
         <tutorial>composition_proposal</tutorial>
         <tutorial>better_pose_proposal</tutorial>
-        <tutorial>param_passing_proposal</tutorial>
       </tutorials>
     </category>
 


### PR DESCRIPTION
# 🦟 Bug fix

Minor fixes to proposals in `manifest.xml`

## Summary

* Fix version number of better pose proposal to 1.9 to match implementation
* Reorder proposals to preserve number sorting

http://sdformat.org/tutorials?cat=pose_semantics_docs&branch=scpeters/fix_proposal_order_version

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
